### PR TITLE
feat: externalize MinIO credentials and endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+**/target/

--- a/exam-api/src/main/java/com/yf/exam/modules/qu/utils/ImageCheckUtils.java
+++ b/exam-api/src/main/java/com/yf/exam/modules/qu/utils/ImageCheckUtils.java
@@ -24,9 +24,12 @@ public class ImageCheckUtils {
         }
 
         // 校验图片地址 - 支持本地上传和MinIO存储
-        boolean isValidUrl = image.startsWith(conf.getUrl()) || 
-                           image.startsWith("http://10.0.201.6:19000/exam-images/");
-        
+        boolean isValidUrl = image.startsWith(conf.getUrl());
+        String minioUrl = System.getenv("MINIO_EXTERNAL_URL");
+        if(StringUtils.isNotBlank(minioUrl)){
+            isValidUrl = isValidUrl || image.startsWith(minioUrl);
+        }
+
         if(!isValidUrl){
             throw new ServiceException(throwMsg);
         }

--- a/exam-api/src/main/resources/prompts/structured_extraction_prompt.txt
+++ b/exam-api/src/main/resources/prompts/structured_extraction_prompt.txt
@@ -50,10 +50,10 @@
   ],
   "images": {
     "img_001": {
-      "id": "img_001",
-      "url": "http://10.0.201.6:19000/exam-images/img_001.png",
-      "type": "docx_embedded"
-    }
+        "id": "img_001",
+        "url": "http://minio.example.com/exam-images/img_001.png",
+        "type": "docx_embedded"
+      }
   }
 }
 ```
@@ -66,7 +66,7 @@
     "quType": 1,
     "level": 1,
     "content": "下列关于函数的描述正确的是？",
-    "image": "http://10.0.201.6:19000/exam-images/img_001.png",
+    "image": "http://minio.example.com/exam-images/img_001.png",
     "analysis": "解析说明",
     "options": [
       {

--- a/exam-api/target/classes/prompts/structured_extraction_prompt.txt
+++ b/exam-api/target/classes/prompts/structured_extraction_prompt.txt
@@ -50,10 +50,10 @@
   ],
   "images": {
     "img_001": {
-      "id": "img_001",
-      "url": "http://10.0.201.6:19000/exam-images/img_001.png",
-      "type": "docx_embedded"
-    }
+        "id": "img_001",
+        "url": "http://minio.example.com/exam-images/img_001.png",
+        "type": "docx_embedded"
+      }
   }
 }
 ```
@@ -66,7 +66,7 @@
     "quType": 1,
     "level": 1,
     "content": "下列关于函数的描述正确的是？",
-    "image": "http://10.0.201.6:19000/exam-images/img_001.png",
+    "image": "http://minio.example.com/exam-images/img_001.png",
     "analysis": "解析说明",
     "options": [
       {

--- a/extract_questions_with_images.py
+++ b/extract_questions_with_images.py
@@ -104,14 +104,20 @@ class DoclingDocument:
 
 app = FastAPI()
 
-# MinIO configuration
+# MinIO configuration from environment variables
+minio_endpoint = os.getenv("MINIO_ENDPOINT", "localhost:9000")
+minio_access_key = os.getenv("MINIO_ACCESS_KEY")
+minio_secret_key = os.getenv("MINIO_SECRET_KEY")
+minio_secure = os.getenv("MINIO_SECURE", "false").lower() == "true"
+minio_external_url = os.getenv("MINIO_EXTERNAL_URL", f"http://{minio_endpoint}")
+bucket_name = os.getenv("MINIO_BUCKET", "exam-images")
+
 minio_client = Minio(
-    "10.0.201.6:19000",
-    access_key="rag_flow",
-    secret_key="infini_rag_flow",
-    secure=False
+    minio_endpoint,
+    access_key=minio_access_key,
+    secret_key=minio_secret_key,
+    secure=minio_secure
 )
-bucket_name = "exam-images"
 
 os.makedirs("./temp", exist_ok=True)
 if not minio_client.bucket_exists(bucket_name):
@@ -134,7 +140,7 @@ def save_to_minio(local_path, object_name):
     """Upload to MinIO and return URL"""
     try:
         minio_client.fput_object(bucket_name, object_name, local_path)
-        return f"http://10.0.201.6:19000/{bucket_name}/{object_name}"
+        return f"{minio_external_url}/{bucket_name}/{object_name}"
     except Exception as e:
         print(f"MinIO upload failed: {e}")
         return None


### PR DESCRIPTION
## Summary
- read MinIO endpoint and credentials from environment variables in extract_questions_with_images.py
- validate MinIO image URLs against `MINIO_EXTERNAL_URL` in ImageCheckUtils
- replace hard-coded internal URLs in structured_extraction_prompt.txt and add .gitignore

## Testing
- `python -m py_compile extract_questions_with_images.py`
- `mvn -q -f exam-api/pom.xml -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_689c260904788325b1aaebd7ff7f7f9e